### PR TITLE
Make sure exit works to quit the virtualenv shell

### DIFF
--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -11,7 +11,7 @@ if command -s pipenv > /dev/null
 
         if not test -n "$PIPENV_ACTIVE"
           if sh -c 'pipenv --venv &> /dev/null'
-            exec pipenv shell
+            pipenv shell
           end
         end
     end


### PR DESCRIPTION
This should fix #4 by not using "exec". "exec" replaces the current shell instead of just running the pipenv shell within it. 