### PR TITLE
Redirect stderr and stdout to /dev/null

### DIFF
--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -10,7 +10,7 @@ if command -s pipenv > /dev/null
         end
 
         if not test -n "$PIPENV_ACTIVE"
-          if sh -c 'pipenv --venv &> /dev/null'
+          if sh -c 'pipenv --venv >/dev/null 2>&1'
             exec pipenv shell
           end
         end


### PR DESCRIPTION
- Fixes issue with always trying to activate pipenv shells
- Closes #2 