### PR TITLE
Inlined output of pipenv --completion to improve startup time

### DIFF
--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -2,7 +2,7 @@
 
 if command -s pipenv > /dev/null
     
-    eval (env _PIPENV_COMPLETE=source-fish pipenv)
+    complete --command pipenv --arguments "(env _PIPENV_COMPLETE=complete-fish COMMANDLINE=(commandline -cp) pipenv)" -f
     
     function __pipenv_shell_activate --on-variable PWD
         if status --is-command-substitution


### PR DESCRIPTION
Possible solution to https://github.com/fisherman/pipenv/issues/9. `fish -c ""; echo $CMD_DURATION` on my machine decreases from ~900 to ~40 by this change alone.

But, is there some big caveat I'm missing here? As far as I have been able to test (i.e. On My Machine™), this works just as good.