### PR TITLE
Automatically exit pipenv shell when leaving directory

### DIFF
--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -9,12 +9,22 @@ if command -s pipenv > /dev/null
             return
         end
         if not test -e "$PWD/Pipfile"
+            if not string match -q "$__pipenv_fish_initial_pwd"/'*' "$PWD/"
+                set -U __pipenv_fish_final_pwd "$PWD"
+                exit
+            end
             return
         end
 
         if not test -n "$PIPENV_ACTIVE"
           if sh -c 'pipenv --venv >/dev/null 2>&1'
+            set -x __pipenv_fish_initial_pwd "$PWD"
             pipenv shell
+            set -e __pipenv_fish_initial_pwd
+            if not test -n "$__pipenv_fish_final_pwd"
+                cd "$__pipenv_fish_final_pwd"
+                set -e __pipenv_fish_final_pwd
+            end
           end
         end
     end


### PR DESCRIPTION
If `~/test/Pipfile` exists and has a valid venv then starting at `~` and
cd'ing to `~/test` will start the pipenv shell as before.
Now when cd'ing to `~/test/foo` nothing will happen as before.

However when cd'ing to outside of `~/test`, eg. `~` or `~/test2` we will
automatically exit the pipenv shell and pass final directory back to the
original shell, which will then switch to that directory

This should fix #5.